### PR TITLE
Add functions to all Nodes

### DIFF
--- a/spec/trees/TreesSpec.js
+++ b/spec/trees/TreesSpec.js
@@ -60,6 +60,7 @@ describe('Trees', function () {
     var rootById = root.indices.id[1];
     var rootByName = root.indices.name['root'];
 
+    expect(rootById).not.toBeUndefined();
     expect(rootById === rootByName).toBeTruthy();
   });
 
@@ -71,6 +72,17 @@ describe('Trees', function () {
     expect(cellularByName.model.id).toEqual(131567);
     expect(cellularByName.children.length).toEqual(1);
     expect(cellularByName.parent.model.name).toEqual('root');
+  });
+
+  it('should have 2 Arabidopses', function () {
+    // given
+    var arabidopsis = root.indices.name['Arabidopsis'];
+
+    // when
+    var leaves = arabidopsis.leafNodes();
+
+    // then
+    expect(leaves.length).toEqual(2);
   });
 
   it('should calculate last common ancestor from the tree', function() {
@@ -106,6 +118,41 @@ describe('Trees', function () {
     expect(plantRoot.model.name).toEqual('Eukaryota');
   });
 
+  it('should find the last common ancestor of all Arabidopses', function() {
+    // given
+    var ath = root.indices.name['Arabidopsis thaliana'];
+    var aly = root.indices.name['Arabidopsis lyrata'];
+
+    // when
+    var aRoot = root.lca([ath, aly]);
+
+    expect(aRoot.model.name).toEqual('Arabidopsis');
+  });
+
+  it('should find the last common ancestor of all Arabidopses using prototype method on Ath', function() {
+    // given
+    var ath = root.indices.name['Arabidopsis thaliana'];
+    var aly = root.indices.name['Arabidopsis lyrata'];
+
+    // when
+    var aRoot = ath.lcaWith([aly]);
+
+    expect(aRoot.model.name).toEqual('Arabidopsis');
+  });
+
+  it('should find the depth of nodes correctly', function() {
+    // given
+    var ath = root.indices.name['Arabidopsis thaliana'],
+        aly = root.indices.name['Arabidopsis lyrata'],
+        euk = root.indices.name['Eukaryota'];
+
+    // then
+    expect(root.depth()).toEqual(0);
+    expect(euk.depth()).toEqual(1);
+    expect(euk.depth(true)).toEqual(2);
+    expect(ath.depth()).toEqual(aly.depth());
+  });
+
   it('should find path between nodes', function() {
     // given
     var from = root.indices.id[39947],
@@ -116,6 +163,22 @@ describe('Trees', function () {
 
     // then
     expect(path.length).toEqual(4);
+    expect(path[0]).toEqual(from);
+    expect(path[path.length - 1]).toEqual(to);
+  });
+
+  it('should find path between nodes using prototype method on all Nodes', function() {
+    // given
+    var from = root.indices.id[39947],
+        to = root.indices.id[4528];
+
+    // when
+    var path = from.pathTo(to);
+
+    // then
+    expect(path.length).toEqual(4);
+    expect(path[0]).toEqual(from);
+    expect(path[path.length - 1]).toEqual(to);
   });
 
 });

--- a/src/taxonomy.js
+++ b/src/taxonomy.js
@@ -65,20 +65,6 @@ module.exports = {
     }
 
     function decorateTree(tree) {
-      tree.depth = function calculateEffectiveNodeDepth(node) {
-        var path = node.getPath()
-          , depth = path.length - 1
-          , compressedDepth = _.reduce(path, function (acc, n) {
-            return acc + (n.compressedNodes ? n.compressedNodes.length : 0);
-          }, 0);
-
-        return depth + compressedDepth;
-      };
-
-      tree.leafNodes = function findAllLeafNodes() {
-        return tree.all(function (node) { return !node.hasChildren(); });
-      };
-
       tree.lca = function lowestCommonAncestor(nodes) {
         var parentNodesInCommon = _.chain(nodes)
           .map(function (node) {
@@ -115,6 +101,39 @@ module.exports = {
       };
     }
 
+    function addPrototypeDecorations(tree) {
+      var prototree = Object.getPrototypeOf(tree);
+
+      prototree.depth = function calculateEffectiveNodeDepth(includeCompressedNodes) {
+        var path = this.getPath()
+          , depth = path.length - 1
+          , compressedDepth;
+
+        if(includeCompressedNodes) {
+          compressedDepth = _.reduce(path, function (acc, n) {
+            return acc + (n.compressedNodes ? n.compressedNodes.length : 0);
+          }, 0);
+          depth += compressedDepth;
+        }
+
+        return depth;
+      };
+
+      prototree.pathTo = function(to) {
+        return tree.pathBetween(this, to);
+      };
+
+      prototree.leafNodes = function findAllLeafNodes() {
+        return this.all(function (node) { return !node.hasChildren(); });
+      };
+
+      prototree.lcaWith = function(otherNodes) {
+        var nodes = _.clone(otherNodes);
+        nodes.push(this);
+        return tree.lca(nodes);
+      }
+    }
+
     function indexTree(tree, attrs) {
       tree.indices = _.chain(attrs)
         .map(function (attr) {
@@ -138,6 +157,7 @@ module.exports = {
     indexTree(tree, ['id', 'name']);
     compressTreePaths(tree);
     decorateTree(tree);
+    addPrototypeDecorations(tree);
 
     return tree;
   }


### PR DESCRIPTION
Move functionality from taxonomy instance to Node prototype so can for example call .leafNodes() on any node in the taxonomy. This will be used in gramene-taxonomy-with-genomes to get result counts for each node.
