### PR TITLE
Filter walk

### DIFF
--- a/spec/trees/TreesSpec.js
+++ b/spec/trees/TreesSpec.js
@@ -200,4 +200,46 @@ describe('Trees', function () {
     expect(path[path.length - 1]).toEqual(to);
   });
 
+  it('should walk the whole tree if filterWalk\'s callback evaluates to true', function() {
+    // given
+    var count = 0;
+
+    // when
+    root.filterWalk(function() {
+      ++count;
+      return true;
+    });
+
+    // then
+    expect(count).toEqual(68);
+  });
+
+  it('should only evaluate one node if filterWalk\'s callback evaluates to false', function() {
+    // given
+    var count = 0;
+
+    // when
+    root.filterWalk(function() {
+      ++count;
+      return false;
+    });
+
+    // then
+    expect(count).toEqual(1);
+  });
+
+  it('should only evaluate a root and "trunk" nodes if filterWalk\'s callback tests for shallow node depth', function() {
+    // given
+    var count = 0;
+
+    // when
+    root.filterWalk(function(node) {
+      ++count;
+      return node.depth() < 3;
+    });
+
+    // then
+    expect(count).toEqual(6);
+  });
+
 });

--- a/src/treemodelExtensions.js
+++ b/src/treemodelExtensions.js
@@ -71,6 +71,16 @@ function addPrototypeDecorations(tree) {
     var nodes = _.clone(otherNodes);
     nodes.push(this);
     return tree.lca(nodes);
+  };
+
+  prototree.filterWalk = function (callback) {
+    function filterWalkRecursive(node) {
+      var evaluateChildren = callback(node);
+      if(evaluateChildren && _.isArray(node.children)) {
+        _.forEach(node.children, filterWalkRecursive)
+      }
+    }
+    return filterWalkRecursive(this);
   }
 }
 


### PR DESCRIPTION
Add filterWalk to Node prototype: walk the tree depth first, conditionally examining child nodes based on truthyness of callback result.
